### PR TITLE
Update spelling error, "designLibaries" to "designLibraries"

### DIFF
--- a/_includes/layouts/component-documentation.njk
+++ b/_includes/layouts/component-documentation.njk
@@ -48,17 +48,17 @@
       
       {% include 'partials/insights.njk' %}
 
-      {% if designLibaries %}
+      {% if designLibraries %}
         <section class="doc-other-libraries">
-          {% if (designLibaries | length ) > 1 %}
+          {% if (designLibraries | length ) > 1 %}
             <h2 class="govuk-heading-l">Other design libraries</h2>
             <p class="govuk-body">Other UK government design libraries that has documented this component.</p>
-            {{ listItemsWithLink("doc-design-library__list", designLibaries) }}
+            {{ listItemsWithLink("doc-design-library__list", designLibraries) }}
           {% else %}
             <h2 class="govuk-heading-l">Other design library</h2>
             <p class="govuk-body">Another UK government design library that has documented this component.</p>
             <p class="govuk-body">
-              <a class="govuk-link" href="{{ designLibaries[0].link }}">{{ designLibaries[0].title }}</a>
+              <a class="govuk-link" href="{{ designLibraries[0].link }}">{{ designLibraries[0].title }}</a>
             </p>
           {% endif %}
         </section>

--- a/docs/components/attachment.md
+++ b/docs/components/attachment.md
@@ -129,7 +129,7 @@ variations:
       title: External attachment
       description: 
         More info can be found in the [component guide](https://components.publishing.service.gov.uk/component-guide/attachment/external_attachment).
-designLibaries:
+designLibraries:
   0:
     title: GOV.UK Component guide
     link: https://components.publishing.service.gov.uk/component-guide/attachment

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -69,7 +69,7 @@ variations:
       
 
       More info can be found in the [component guide](https://components.publishing.service.gov.uk/component-guide/breadcrumbs/with_border).
-designLibaries:
+designLibraries:
   0:
     title: GOV.UK Design System
     link: https://design-system.service.gov.uk/components/breadcrumbs/

--- a/docs/components/content-list.md
+++ b/docs/components/content-list.md
@@ -137,7 +137,7 @@ insights:
     link: https://docs.google.com/presentation/d/1wsiH0OJPyS9DtxvUXri-tNkqFhU6N00xjdsWSAHK2Fw/edit#slide=id.g1006224b8f4_0_85
     description: Project debrief that provides project context and opportunities for improvements
     date: November 2022
-designLibaries:
+designLibraries:
   0:
     title: GOV.UK Component guide
     link: https://components.publishing.service.gov.uk/component-guide/contents_list


### PR DESCRIPTION
There was a spelling error of parameter. Missed an `r` in the spelling of `libraries`.