### PR TITLE
Added one inight to document collections

### DIFF
--- a/docs/frontend-templates/document-collections.md
+++ b/docs/frontend-templates/document-collections.md
@@ -163,7 +163,12 @@ insights:
   0:
     title: Prototype testing specialist topics
     link: https://docs.google.com/presentation/d/1pqbXzYPbVs11fuOpa4P9sRv7TLT8wbRTniuO_ANC7sM/edit#slide=id.g10d42026b8_2_0
-    description: Collections pages were used as navigation pages for specialist topics (the equivalent of a mainstream browse topic or sub-topic page). We tested with 5 accountants, frequent users of GOV.UK, and using desktop. Users had no difficulties with the page design, and successfully used the page to navigate. Including a short description under each link within the collection helped users to choose between the options and aided navigation. 
-    Relevant people or team: Rob Sewell, Navigation and Presentation team
+    description:
+      "
+      Collections pages were used as navigation pages for specialist topics (the equivalent of a mainstream browse topic or sub-topic page). We tested with 5 accountants, frequent users of GOV.UK, and using desktop.
+      
+      
+      Users had no difficulties with the page design, and successfully used the page to navigate. Including a short description under each link within the collection helped users to choose between the options and aided navigation.
+      "
     date: September 2022
 ---


### PR DESCRIPTION
Needs some help:
- The insights descriptions was given to me as two paragraphs but I had to make it one for it to render. Can we make it so this section accepts line breaks?
- We have a section of "relevant people and team" that added but it does not display. Can we display this section somehow? this will help people know who to talk to for more information.