### PR TITLE
Remove every instance of the phase banner in the design library

### DIFF
--- a/_includes/layouts/about.njk
+++ b/_includes/layouts/about.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/base.njk" %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">    
     <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/_includes/layouts/component-documentation.njk
+++ b/_includes/layouts/component-documentation.njk
@@ -1,10 +1,6 @@
 {% extends "layouts/base.njk" %}
 {% from 'macros/unordered-list-item-with-link.njk' import listItemsWithLink %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     {% include 'partials/sub-navigation.njk' %}

--- a/_includes/layouts/frontend-template-documentation.njk
+++ b/_includes/layouts/frontend-template-documentation.njk
@@ -1,10 +1,6 @@
 {% extends "layouts/base.njk" %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     {% include 'partials/sub-navigation.njk' %}

--- a/_includes/layouts/frontend-template-index-documentation.njk
+++ b/_includes/layouts/frontend-template-index-documentation.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/base.njk" %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     {% include 'partials/sub-navigation.njk' %}

--- a/_includes/layouts/landing-page.njk
+++ b/_includes/layouts/landing-page.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/base.njk" %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     {% include 'partials/sub-navigation.njk' %}

--- a/_includes/layouts/pattern-documentation.njk
+++ b/_includes/layouts/pattern-documentation.njk
@@ -1,10 +1,6 @@
 {% extends "layouts/base.njk" %}
 {% from 'macros/unordered-list-item-with-link.njk' import listItemsWithLink %}
 
-{% block beforeContent %}
-  {% include 'partials/phase-banner.njk' %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     {% include 'partials/sub-navigation.njk' %}

--- a/_includes/partials/phase-banner.njk
+++ b/_includes/partials/phase-banner.njk
@@ -1,8 +1,0 @@
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-
-{{ govukPhaseBanner({
-  tag: {
-    text: "Alpha"
-  },
-  html: 'This is a new service. Help us improve it and <a class="govuk-link" href="#">give your feedback (opens in new tab)</a>.'
-}) }}


### PR DESCRIPTION
Removed every instance of the phase banner within the design library.

We won't be setting up a Smart Survey as initially intended, based on Chris Marshall's suggestion that desk research will suffice, given we are essentially testing with GOV.UK designers.