### PR TITLE
Rename Design Library

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,13 +1,13 @@
 ---
 layout: about
 title: About
-description: The GOV.UK Pattern Library is a place for sharing frontend templates, components and patterns on the GOV.UK website and publishing tools. 
+description: The GOV.UK Publishing Design System is a place for sharing frontend templates, components and patterns on the GOV.UK website and publishing tools. 
 ---
-By encouraging collaboration across disciplines, we can create a more consistent, efficient and user-friendly GOV.UK website. The Pattern Library ensures that teams within the GOV.UK programme are not recreating existing design solutions, and focus on delivering immediate value to end-users.
+By encouraging collaboration across disciplines, we can create a more consistent, efficient and user-friendly GOV.UK website. The Publishing Design System ensures that teams who work on the publishing platform within the GOV.UK programme are not recreating existing design solutions, and focus on delivering immediate value to end-users.
 
 It will also help onboard new designers and familiarise them with GOV.UK’s design approach.
 
-## What is the GOV.UK Pattern Library not?
-The GOV.UK Pattern Library does not replace the [GOV.UK Design System](https://design-system.service.gov.uk/).
+## What is the GOV.UK Publishing Design System not?
+The GOV.UK Publishing Design System does not replace the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-Frontend templates, components and patterns in the Pattern Library should not duplicate those in the GOV.UK Design System. Things that have relevance outside of the GOV.UK website should be contributed back to the Design System.
+Components, patterns and frontend templates in the Publishing Design System should not duplicate those in the GOV.UK Design System. Things that have relevance outside of the GOV.UK website should be contributed back to the Design System.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 homepage: true
 layout: homepage
-title: A pattern library for anyone working on the GOV.UK website
+title: A design system for anyone working on GOV.UK's publishing platform
 description: As an extension of GOV.UK Design System, aimed at people working in the GOV.UK programme at the Government Digital Service.
 whatsNewDate:
 whatsNew: 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -6,7 +6,7 @@ module.exports = function(eleventyConfig) {
     homeKey: "",
     showBreadcrumbs: false,
     header: {
-      productName: 'Pattern Library'
+      productName: "Publishing Design System"
     },
     navigation: {
       items: [


### PR DESCRIPTION
# Context
_Design Library_ sounds too close to _Design System_.

The idea is to replace any mention of _Design Library_ with _Pattern Library_ to help further differentiate it from _Design System_

# Preview
https://deploy-preview-28--govukdesignlibrary.netlify.app/