### PR TITLE
Intro text added before listing out components

### DIFF
--- a/_includes/layouts/frontend-template-documentation.njk
+++ b/_includes/layouts/frontend-template-documentation.njk
@@ -154,7 +154,7 @@
         <section class="doc-components">
           <h2 class="govuk-heading-l">Components</h2>
           <table class="govuk-table">
-            <caption class="govuk-table__caption govuk-table__caption--m">The components within the {{ title | lower }} frontend template</caption>
+            <caption class="govuk-table__caption govuk-table__caption--m">The components used within the {{ title | lower }} frontend template</caption>
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header">Component</th>

--- a/_includes/layouts/pattern-documentation.njk
+++ b/_includes/layouts/pattern-documentation.njk
@@ -15,7 +15,7 @@
       {% if components[0].title and components[0].link %}
         <section class="doc-components">
           <h2 class="govuk-heading-l">Components</h2>
-          <p class="govuk-body">The components within the {{ title | lower }} pattern:</p>
+          <p class="govuk-body">The components used within the {{ title | lower }} pattern:</p>
           {{ listItemsWithLink("doc-components__list", components) }}
         </section>
       {% endif %}


### PR DESCRIPTION
# Context
As suggested by Calum Ryan, be good to have an intro text before listing out all the components in both the frontend template and for a pattern.

Good for accessiblity

# Preview
https://deploy-preview-30--govukdesignlibrary.netlify.app/