### PR TITLE
Report an accessibility issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/07-accessibility-issue.yml
+++ b/.github/ISSUE_TEMPLATE/07-accessibility-issue.yml
@@ -1,0 +1,52 @@
+name: Report an accessibility issue or suggest an improvement to the Publishing Design Guide
+description: Use this template to report an accessibility issue or suggest an improvement that can be made to the Publishing Design Guide
+title: "[Enter a brief title of the accessibility issue or suggested improvement]"
+labels: ["accessibility"]
+projects: ["alphagov/97"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Steps to report an accessibilty issue or suggestion
+        - Update the title with a brief description of the issue or suggestion
+        - Enter the details below to the best of your ability 
+  - type: textarea
+    attributes:
+      label: "Accessibility issue or suggested improvement"
+      description: "Describe what the accessibility issue or suggested improvement is"
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Affected platforms
+      description:
+      multiple: false
+      options: 
+        - Web
+        - Mobile
+        - Both
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Affected platforms
+      description: Which platform does the issue or suggestion affect?
+      multiple: false
+      options: 
+        - Web
+        - Mobile
+        - Both
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Impact on assitive technology / accessibility aids
+      description:
+      options: 
+        - VoiceOver
+        - Speech-to-text software
+        - Screen magnifier
+        - Custom styles override
+        - Dark mode
+    validations:
+      required: false


### PR DESCRIPTION
# Context
- This is a template for a form to report any Accessibility issues with the GOV.UK Publishing Design Guide
- Plus, this form could also be used to suggest accessibility improvments