### PR TITLE
Update link to report issue

### DIFF
--- a/_includes/partials/instructions-report-issue.njk
+++ b/_includes/partials/instructions-report-issue.njk
@@ -1,6 +1,16 @@
 <p class="govuk-body">If you happen to come across an issue:</p>
 <ol class="govuk-list govuk-list--number">
-  <li>Report it on <a href="{{ githubIssueLink }}" class="govuk-link" rel="noopener noreferrer" target="_blank">Github (opens in a new tab)</a>.</li>
+  <li>Report it on 
+    <a class="govuk-link" rel="noopener noreferrer" target="_blank" href=
+      "{% if sectionKey === "Frontend templates" %}
+        https://google.com
+      {% elif sectionKey === "Components" %}
+        https://theverge.com
+      {% elif sectionKey === "Patterns" %}
+        https://bbc.com
+      {% endif %}" 
+    >Github (opens in a new tab)</a>.
+  </li>
   <li>Once the issue has been added, update this document by adding the title and Github Issue's link.</li>
   <li>Give yourself a high-five.</li>
 </ol>

--- a/_includes/partials/instructions-report-issue.njk
+++ b/_includes/partials/instructions-report-issue.njk
@@ -3,11 +3,11 @@
   <li>Report it on 
     <a class="govuk-link" rel="noopener noreferrer" target="_blank" href=
       "{% if sectionKey === "Frontend templates" %}
-        https://google.com
+        https://github.com/alphagov/govuk-design-guide/issues/new?assignees=&labels=frontend+template&projects=alphagov%2F100&template=11-frontend-template-issue.yml&title=%5BEnter+the+name+of+the+frontend+template%5D%3A+%5BEnter+the+issue+with+frontend+template%5D
       {% elif sectionKey === "Components" %}
-        https://theverge.com
+        https://github.com/alphagov/govuk-design-guide/issues/new?assignees=&labels=component&projects=alphagov%2F100&template=09-component-issue.yml&title=%5BEnter+the+name+of+the+component%5D%3A+%5BEnter+the+issue+with+component%5D
       {% elif sectionKey === "Patterns" %}
-        https://bbc.com
+        https://github.com/alphagov/govuk-design-guide/issues/new?assignees=&labels=pattern&projects=alphagov%2F100&template=10-pattern-issue.yml&title=%5BEnter+the+name+of+the+pattern%5D%3A+%5BEnter+the+issue+with+pattern%5D
       {% endif %}" 
     >Github (opens in a new tab)</a>.
   </li>

--- a/_includes/partials/issues.njk
+++ b/_includes/partials/issues.njk
@@ -12,10 +12,8 @@
         <h2 class="doc-issues__title govuk-heading-l">Existing issues with this pattern</h2>
       {% endif %}
       {{ listItemsWithLink("doc-issues__list", issues) }}
-      {% if githubIssueLink %}
-        {{ reportIssue("h3", "m") }}
-        {% include "./instructions-report-issue.njk" %}
-      {% endif %}
+      {{ reportIssue("h3", "m") }}
+      {% include "./instructions-report-issue.njk" %}
     {% else %}
       {% if sectionKey === "Frontend templates" %}
         <h2 class="doc-issues__title govuk-heading-l">An existing issue with this frontend template</h2>
@@ -27,15 +25,11 @@
       <p class="govuk-body">
         <a class="govuk-link" href="{{ issues[0].link }}">{{ issues[0].title }}</a>
       </p>
-      {% if githubIssueLink %}
-        {{ reportIssue("h3", "m") }}
-        {% include "./instructions-report-issue.njk" %}
-      {% endif %}
-    {% endif %}
-{% else %}
-    {% if githubIssueLink %}
-      {{ reportIssue("h2", "l") }}
+      {{ reportIssue("h3", "m") }}
       {% include "./instructions-report-issue.njk" %}
     {% endif %}
+{% else %}
+    {{ reportIssue("h2", "l") }}
+    {% include "./instructions-report-issue.njk" %}
   </section>
 {% endif %}

--- a/docs/components/*component-documentation-template.md
+++ b/docs/components/*component-documentation-template.md
@@ -78,11 +78,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/attachment.md
+++ b/docs/components/attachment.md
@@ -200,11 +200,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -156,11 +156,6 @@ designSystems:
     title: Ministry of Defence Design System
     link: https://design-system.service.mod.gov.uk/components/breadcrumbs/
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/content-list.md
+++ b/docs/components/content-list.md
@@ -206,11 +206,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/feedback.md
+++ b/docs/components/feedback.md
@@ -139,11 +139,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/global-banner.md
+++ b/docs/components/global-banner.md
@@ -94,11 +94,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/print-link.md
+++ b/docs/components/print-link.md
@@ -119,11 +119,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/components/single-page-notification-button.md
+++ b/docs/components/single-page-notification-button.md
@@ -84,11 +84,6 @@ designSystems:
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
 
-# How to report an issue with this component
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the component's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/*frontend-template-documentation-template.md
+++ b/docs/frontend-templates/*frontend-template-documentation-template.md
@@ -132,11 +132,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/answer.md
+++ b/docs/frontend-templates/answer.md
@@ -282,11 +282,6 @@ insights:
     link: https://docs.google.com/spreadsheets/d/1f4fSsIxkCfWiKNV9qgE_sep61f5EbKxU58wTWCsGw60/edit?gid=2140166644#gid=2140166644
     documentFormat: Google Sheets
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/calendar.md
+++ b/docs/frontend-templates/calendar.md
@@ -309,11 +309,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/completed-transaction.md
+++ b/docs/frontend-templates/completed-transaction.md
@@ -317,11 +317,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/detailed-guide.md
+++ b/docs/frontend-templates/detailed-guide.md
@@ -394,11 +394,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/document-collections.md
+++ b/docs/frontend-templates/document-collections.md
@@ -456,11 +456,6 @@ insights:
     link: https://docs.google.com/presentation/d/1pqbXzYPbVs11fuOpa4P9sRv7TLT8wbRTniuO_ANC7sM/edit#slide=id.g10d42026b8_2_0
     documentFormat: Google Slides
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/case-studies-finder.md
+++ b/docs/frontend-templates/finder/case-studies-finder.md
@@ -267,11 +267,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/departments-agencies-public-bodies-finder.md
+++ b/docs/frontend-templates/finder/departments-agencies-public-bodies-finder.md
@@ -267,11 +267,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/groups-finder.md
+++ b/docs/frontend-templates/finder/groups-finder.md
@@ -252,11 +252,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/hmrc-contacts-finder.md
+++ b/docs/frontend-templates/finder/hmrc-contacts-finder.md
@@ -282,11 +282,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/index.md
+++ b/docs/frontend-templates/finder/index.md
@@ -258,11 +258,6 @@ insights:
     link: https://docs.google.com/document/d/1x84j4IvpQcXy8WpG2Mx9YrO5GFZeOYOToiSzK9ax6Uk/edit?usp=sharing
     documentFormat: Google Docs
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/people-finder.md
+++ b/docs/frontend-templates/finder/people-finder.md
@@ -252,11 +252,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/search.md
+++ b/docs/frontend-templates/finder/search.md
@@ -342,11 +342,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/specialist-document-finder.md
+++ b/docs/frontend-templates/finder/specialist-document-finder.md
@@ -501,11 +501,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/statistical-data-sets-finder.md
+++ b/docs/frontend-templates/finder/statistical-data-sets-finder.md
@@ -327,11 +327,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/supergroup-finder.md
+++ b/docs/frontend-templates/finder/supergroup-finder.md
@@ -405,11 +405,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/topical-events-finder.md
+++ b/docs/frontend-templates/finder/topical-events-finder.md
@@ -327,11 +327,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/finder/world-organisation-finder.md
+++ b/docs/frontend-templates/finder/world-organisation-finder.md
@@ -251,11 +251,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/guide.md
+++ b/docs/frontend-templates/guide.md
@@ -309,11 +309,6 @@ insights:
     link: https://docs.google.com/spreadsheets/d/1lW8AJ1HbnFv06gkDB6OUGFPZjeXQbaECWW3t4AT2YPk/edit?gid=0#gid=0
     documentFormat: Google Sheets
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/homepage.md
+++ b/docs/frontend-templates/homepage.md
@@ -251,11 +251,6 @@ insights:
     link: https://docs.google.com/presentation/d/13YlznozVei-m69S0hL8VAm3mMzHMSoa88EVctgDjFm0/edit?usp=sharing
     documentFormat: Google Slides
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/mainstream-browse/index.md
+++ b/docs/frontend-templates/mainstream-browse/index.md
@@ -202,11 +202,6 @@ insights:
     link: https://docs.google.com/document/d/1aCUbrdqaCCF6mblDfddw1Wck_DmTsHADMYR-Ny-9Xw4/edit#heading=h.yo2pwekzv7t0
     documentFormat: Google Docs
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/mainstream-browse/level-one.md
+++ b/docs/frontend-templates/mainstream-browse/level-one.md
@@ -270,11 +270,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/mainstream-browse/level-two.md
+++ b/docs/frontend-templates/mainstream-browse/level-two.md
@@ -246,11 +246,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/smart-answer/github-smart-answer.md
+++ b/docs/frontend-templates/smart-answer/github-smart-answer.md
@@ -384,11 +384,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/smart-answer/index.md
+++ b/docs/frontend-templates/smart-answer/index.md
@@ -148,11 +148,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/smart-answer/simple-smart-answer.md
+++ b/docs/frontend-templates/smart-answer/simple-smart-answer.md
@@ -369,11 +369,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/special-route.md
+++ b/docs/frontend-templates/special-route.md
@@ -228,11 +228,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/step-by-step-nav.md
+++ b/docs/frontend-templates/step-by-step-nav.md
@@ -270,11 +270,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/topical-events/about.md
+++ b/docs/frontend-templates/topical-events/about.md
@@ -289,11 +289,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/topical-events/index.md
+++ b/docs/frontend-templates/topical-events/index.md
@@ -375,11 +375,6 @@ insights:
     link: https://app.mural.co/t/govukdelivery7534/m/govukdelivery7534/1674139116917/714724969d90020cd15e1ce41153c4c43fca5101?sender=u5494c2264a5f0c5c71eb1671
     documentFormat: Mural board
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/frontend-templates/transaction.md
+++ b/docs/frontend-templates/transaction.md
@@ -375,11 +375,6 @@ insights:
     link: #Delete this comment before entering the URL of the insight document.
     documentFormat: #Delete this comment before entering the format of the insight document. Example: (1) Google Docs, (2) Google Sheets, and (3) Google Slides.
 
-# How to report an issue with this frontend template
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the frontend template's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/patterns/*pattern-documentation-template.md
+++ b/docs/patterns/*pattern-documentation-template.md
@@ -78,11 +78,6 @@ insights:
 accessibilty:
   #Delete this comment before entering the accessibility criteria for this pattern.
 
-# How to report an issue with this pattern
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the pattern's codebase exists.
-githubIssueLink: #Delete this comment before entering the URL of the page to create a new GitHub issue.
-
 # Existing issues with this pattern
 # List of all the issues that are associated with this pattern, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:

--- a/docs/patterns/search-filter.md
+++ b/docs/patterns/search-filter.md
@@ -109,11 +109,6 @@ insights:
 accessibilty:
   There was an accessibility driven design change made to the mobile filters around 2021.
 
-# How to report an issue with this pattern
-# This will display instrucions on how to report an issue via GitHub.
-# Consult with a developer to confirm the GitHub where the pattern's codebase exists.
-githubIssueLink: https://github.com/alphagov/govuk_publishing_components/issues/new
-
 # Existing issues with this pattern
 # List of all the issues that are associated with this pattern, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
 issues:


### PR DESCRIPTION
# Context
- Creating Issue templates as per PR #101
- Now pointing at appropriate GitHub issue reports that aligns with Publishing Design Guide Repo
- As a result, removed any logic and mention of the variable `githubIssueLink`