### PR TITLE
Add a custom title value for homepage

### DIFF
--- a/_includes/layouts/homepage.njk
+++ b/_includes/layouts/homepage.njk
@@ -6,6 +6,9 @@
       title: {
         html: title | smart
       } if title,
+      title: {
+        html: customPageTitle | smart
+      } if customPageTitle,
       description: {
         html: description | markdown("inline") | noOrphans
       } if description,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 ---
 homepage: true
 layout: homepage
-title: Design pages that help users find information and services on GOV.UK
+title: Home
+customPageTitle: Design pages that help users find information and services on GOV.UK
 description: The GOV.UK Publishing Design Guide is an extension of the GOV.UK Design System, aimed at people working in the GOV.UK programme at the Government Digital Service.
 image:
   src: /assets/images/homepage.svg


### PR DESCRIPTION
The change introduces a custom page value to the template, making the homepage text that appears in the `<title>` element more identifiable and particularly beneficial for accessibility to know where they are.