### PR TITLE
Ability to have external links

### DIFF
--- a/_includes/layouts/component-documentation.njk
+++ b/_includes/layouts/component-documentation.njk
@@ -21,7 +21,7 @@
             {{ listItemsWithLink("doc-design-systems__list", designSystems) }}
           {% else %}
             <p class="govuk-body">
-              <a class="govuk-link" href="{{ designSystems[0].link }}">{{ designSystems[0].title }}</a>
+              <a class="govuk-link" href="{{ designSystems[0].link }}"  rel="noopener noreferrer" target="_blank">{{ designSystems[0].title }} (opens in a new tab)</a>
             </p>
           {% endif %}
         </section>

--- a/_includes/macros/unordered-list-item-with-link.njk
+++ b/_includes/macros/unordered-list-item-with-link.njk
@@ -7,6 +7,12 @@
             <span lang="cy">
               <a class="govuk-link" href="{{ listItem[i].link }}">{{ listItem[i].title }}</a>
             </span>
+          {% elif listItem[i].welsh == true and listItem[i].external == true %}
+            <span lang="cy">
+              <a class="govuk-link" href="{{ listItem[i].link }}" rel="noopener noreferrer" target="_blank">{{ listItem[i].title }} (opens in a new tab)</a>
+            </span>
+          {% elif listItem[i].external == true %}
+            <a class="govuk-link" href="{{ listItem[i].link }}" rel="noopener noreferrer" target="_blank">{{ listItem[i].title }} (opens in a new tab)</a>
           {% else %}
             <a class="govuk-link" href="{{ listItem[i].link }}">{{ listItem[i].title }}</a>
           {% endif %}

--- a/_includes/partials/issues.njk
+++ b/_includes/partials/issues.njk
@@ -23,7 +23,7 @@
         <h2 class="doc-issues__title govuk-heading-l">An existing issue with this pattern</h2>
       {% endif %}
       <p class="govuk-body">
-        <a class="govuk-link" href="{{ issues[0].link }}">{{ issues[0].title }}</a>
+        <a class="govuk-link" href="{{ issues[0].link }}" rel="noopener noreferrer" target="_blank">{{ issues[0].title }} (opens in a new link)</a>
       </p>
       {{ reportIssue("h3", "m") }}
       {% include "./instructions-report-issue.njk" %}

--- a/docs/components/*component-documentation-template.md
+++ b/docs/components/*component-documentation-template.md
@@ -82,6 +82,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -91,4 +92,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/components/*component-documentation-template.md
+++ b/docs/components/*component-documentation-template.md
@@ -82,7 +82,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -92,5 +96,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---

--- a/docs/components/attachment.md
+++ b/docs/components/attachment.md
@@ -204,6 +204,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -213,4 +214,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Audit of all attachment component variations
     link: https://github.com/alphagov/govuk_publishing_components/issues/4146
+    external: true
 ---

--- a/docs/components/attachment.md
+++ b/docs/components/attachment.md
@@ -204,7 +204,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -214,5 +218,6 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Audit of all attachment component variations
     link: https://github.com/alphagov/govuk_publishing_components/issues/4146
-    external: true
+    external:
+      true
 ---

--- a/docs/components/attachment.md
+++ b/docs/components/attachment.md
@@ -204,7 +204,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set to "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -152,17 +152,20 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: GOV.UK Design System
     link: https://design-system.service.gov.uk/components/breadcrumbs/
-    external: true
+    external:
+      true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: NHS Digital service manual
     link: https://service-manual.nhs.uk/design-system/components/breadcrumbs
-    external: true
+    external:
+      true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Ministry of Defence Design System
     link: https://design-system.service.mod.gov.uk/components/breadcrumbs/
-    external: true
+    external:
+      true
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -172,22 +175,26 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Breadcrumbs don't show the page you are on. Is that a problem?
     link: https://github.com/alphagov/govuk_publishing_components/issues/4257
-    external: true
+    external:
+      true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: We can’t give specialist document finders a parent taxonomy topic, because there’s no route back. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4258
-    external: true
+    external:
+      true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Parts or all of breadcrumbs missing on some pages
     link: https://github.com/alphagov/govuk_publishing_components/issues/4259
-    external: true
+    external:
+      true
   3:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: When content is tagged to multiple topics the breadcrumb component selects one in alphabetical order. Are there alternatives that would work better for users?
     link: https://github.com/alphagov/govuk_publishing_components/issues/4260
-    external: true
+    external:
+      true
 
 
 # Kati's additional suggestions

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -152,14 +152,17 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: GOV.UK Design System
     link: https://design-system.service.gov.uk/components/breadcrumbs/
+    external: true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: NHS Digital service manual
     link: https://service-manual.nhs.uk/design-system/components/breadcrumbs
+    external: true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Ministry of Defence Design System
     link: https://design-system.service.mod.gov.uk/components/breadcrumbs/
+    external: true
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -169,18 +172,22 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Breadcrumbs don't show the page you are on. Is that a problem?
     link: https://github.com/alphagov/govuk_publishing_components/issues/4257
+    external: true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: We can’t give specialist document finders a parent taxonomy topic, because there’s no route back. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4258
+    external: true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Parts or all of breadcrumbs missing on some pages
     link: https://github.com/alphagov/govuk_publishing_components/issues/4259
+    external: true
   3:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: When content is tagged to multiple topics the breadcrumb component selects one in alphabetical order. Are there alternatives that would work better for users?
     link: https://github.com/alphagov/govuk_publishing_components/issues/4260
+    external: true
 
 
 # Kati's additional suggestions

--- a/docs/components/content-list.md
+++ b/docs/components/content-list.md
@@ -210,6 +210,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -219,21 +220,26 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: There is no visual differentiation between navigating within a page and across pages.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4261
+    external: true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The components gives very low visibility of which page in a list is active.  
     link: https://github.com/alphagov/govuk_publishing_components/issues/4262
+    external: true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The contents list is too low in the type hierarchy.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4263
+    external: true
   3:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The m-dash is unusual as a visual marker on gov.uk.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4264
+    external: true
   4:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Inconsistent position in source order
     link: https://github.com/alphagov/govuk_publishing_components/issues/4265
+    external: true
 
 ---

--- a/docs/components/content-list.md
+++ b/docs/components/content-list.md
@@ -210,7 +210,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -220,26 +224,30 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: There is no visual differentiation between navigating within a page and across pages.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4261
-    external: true
+    external:
+      true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The components gives very low visibility of which page in a list is active.  
     link: https://github.com/alphagov/govuk_publishing_components/issues/4262
-    external: true
+    external:
+      true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The contents list is too low in the type hierarchy.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4263
-    external: true
+    external:
+      true
   3:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: The m-dash is unusual as a visual marker on gov.uk.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4264
-    external: true
+    external:
+      true
   4:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Inconsistent position in source order
     link: https://github.com/alphagov/govuk_publishing_components/issues/4265
-    external: true
-
+    external:
+      true
 ---

--- a/docs/components/feedback.md
+++ b/docs/components/feedback.md
@@ -143,7 +143,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -153,5 +157,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---

--- a/docs/components/feedback.md
+++ b/docs/components/feedback.md
@@ -143,6 +143,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -152,4 +153,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/components/global-banner.md
+++ b/docs/components/global-banner.md
@@ -98,6 +98,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -107,4 +108,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/components/global-banner.md
+++ b/docs/components/global-banner.md
@@ -98,7 +98,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -108,5 +112,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---

--- a/docs/components/print-link.md
+++ b/docs/components/print-link.md
@@ -123,7 +123,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -133,15 +137,18 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Not all pages display the print link.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4266
-    external: true
+    external:
+      true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Where print link is repeated at the top and bottom of a page the lock-up is currently inconsistent. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4267
-    external: true
+    external:
+      true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: In dark mode the icon is not visible. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4268
-    external: true
+    external:
+      true
 ---

--- a/docs/components/print-link.md
+++ b/docs/components/print-link.md
@@ -123,6 +123,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -132,12 +133,15 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Not all pages display the print link.
     link: https://github.com/alphagov/govuk_publishing_components/issues/4266
+    external: true
   1:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: Where print link is repeated at the top and bottom of a page the lock-up is currently inconsistent. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4267
+    external: true
   2:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: In dark mode the icon is not visible. 
     link: https://github.com/alphagov/govuk_publishing_components/issues/4268
+    external: true
 ---

--- a/docs/components/single-page-notification-button.md
+++ b/docs/components/single-page-notification-button.md
@@ -88,7 +88,11 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -98,5 +102,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---

--- a/docs/components/single-page-notification-button.md
+++ b/docs/components/single-page-notification-button.md
@@ -88,6 +88,7 @@ designSystems:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the name of the Publishing Design Guide.
     link: #Delete this comment before entering the URL of the corresponding Publishing Design Guide.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Existing issues with this component
 # List of all the issues that are associated with this component, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.
@@ -97,4 +98,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/frontend-templates/*frontend-template-documentation-template.md
+++ b/docs/frontend-templates/*frontend-template-documentation-template.md
@@ -49,6 +49,7 @@ examples:
         # true = The webpage is in Welsh
         # false = The webpage is not in Welsh, but rather in English
       #Delete this comment before entering whether the webpage is in Welsh or not.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
     
 # The Content Data (Production) URL this frontend template
 # Filter the document type in content data and copy the URL in your browser's address bar.
@@ -140,4 +141,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/frontend-templates/*frontend-template-documentation-template.md
+++ b/docs/frontend-templates/*frontend-template-documentation-template.md
@@ -49,7 +49,11 @@ examples:
         # true = The webpage is in Welsh
         # false = The webpage is not in Welsh, but rather in English
       #Delete this comment before entering whether the webpage is in Welsh or not.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
     
 # The Content Data (Production) URL this frontend template
 # Filter the document type in content data and copy the URL in your browser's address bar.

--- a/docs/patterns/*pattern-documentation-template.md
+++ b/docs/patterns/*pattern-documentation-template.md
@@ -62,6 +62,7 @@ components:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: #Delete this comment before entering the name of the component used within this pattern.
     link: #Delete this comment before entering the URL of the documentation for said component.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 
 # Evidence and insights for this pattern
 # List out all past documentation/supporting material with regards to or realted to this pattern. It can include (1) past design documentation, (2) research findings, and (3) presentations.
@@ -91,4 +92,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/patterns/*pattern-documentation-template.md
+++ b/docs/patterns/*pattern-documentation-template.md
@@ -62,7 +62,11 @@ components:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: #Delete this comment before entering the name of the component used within this pattern.
     link: #Delete this comment before entering the URL of the documentation for said component.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 
 # Evidence and insights for this pattern
 # List out all past documentation/supporting material with regards to or realted to this pattern. It can include (1) past design documentation, (2) research findings, and (3) presentations.
@@ -92,5 +96,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---

--- a/docs/patterns/search-filter.md
+++ b/docs/patterns/search-filter.md
@@ -77,22 +77,27 @@ components:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Search
     link: https://components.publishing.service.gov.uk/component-guide/search
+    external: true
   1:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Expander
     link: https://govuk-finder-frontend.herokuapp.com/component-guide/expander
+    external: true
   2:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Form date input
     link: https://components.publishing.service.gov.uk/component-guide/date_input
+    external: true
   3:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Option select
     link: https://components.publishing.service.gov.uk/component-guide/option_select
+    external: true
   4:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Form radio button
     link: https://components.publishing.service.gov.uk/component-guide/radio
+    external: true
 
 # Evidence and insights for this pattern
 # List out all past documentation/supporting material with regards to or realted to this pattern. It can include (1) past design documentation, (2) research findings, and (3) presentations.
@@ -122,4 +127,5 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
+    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
 ---

--- a/docs/patterns/search-filter.md
+++ b/docs/patterns/search-filter.md
@@ -77,27 +77,32 @@ components:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Search
     link: https://components.publishing.service.gov.uk/component-guide/search
-    external: true
+    external:
+      true
   1:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Expander
     link: https://govuk-finder-frontend.herokuapp.com/component-guide/expander
-    external: true
+    external:
+      true
   2:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Form date input
     link: https://components.publishing.service.gov.uk/component-guide/date_input
-    external: true
+    external:
+      true
   3:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Option select
     link: https://components.publishing.service.gov.uk/component-guide/option_select
-    external: true
+    external:
+      true
   4:
     # Both title and link are REQUIRED in order for this information to be displayed on the page.
     title: Form radio button
     link: https://components.publishing.service.gov.uk/component-guide/radio
-    external: true
+    external:
+      true
 
 # Evidence and insights for this pattern
 # List out all past documentation/supporting material with regards to or realted to this pattern. It can include (1) past design documentation, (2) research findings, and (3) presentations.
@@ -127,5 +132,9 @@ issues:
     # Both title and link are REQUIRED in order to display this information on the page.
     title: #Delete this comment before entering the title of the GitHub issue.
     link: #Delete this comment before entering the URL of the corresponding GitHub issue.
-    external: #Set "external" to "true" if the link is outside the Publishing Design Guide. Set "external" to "false" if the link is within the Publishing Design Guide
+    external:
+      # Options on whether the webpage is an external:
+        # true = The link is outside the Publishing Design Guide
+        # false = The link is within the Publishing Design Guide
+      #Delete this comment before entering whether the link is external or not.
 ---


### PR DESCRIPTION
Related to an issue brought forth by @ChristineWuerth 

Good idea to have any pages outside the Publishing Design Guide open in a new tab. While internal links will not.