### PR TITLE
Update ordering when inputting insights

### DIFF
--- a/_includes/partials/insights.njk
+++ b/_includes/partials/insights.njk
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for i in range(0, insights | length ) %}
+        {% for i in range(0, insights | length ) | reverse %}
           {% if insights[i].link and insights[i].title %}
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">{{ insights[i].date }}</th>

--- a/docs/components/content-list.md
+++ b/docs/components/content-list.md
@@ -130,12 +130,13 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: May 2024
+    date: August 2022
     description:
-     'A research and design project on travel advice identified that the contents list contributes to users struggling to find information they need. In the given context, working with users enabled the team to streamline the content list from 10 items down to 5. This resulted in less confusion, fewer places to look, and Emergency content info more easily found.'
-    title: Travel Advice research and design summary 2022 to 23 (pp. 8)
-    link: https://docs.google.com/presentation/d/1Qx8o2ppZgnHbXe0UAT1f5XSsTL8-QaCv/edit?usp=sharing&ouid=105832416597570443289&rtpof=true&sd=true
-    documentFormat: Google Slides
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+      'The content audit discovery summarised a list of inconsistencies and issues with this component and offers proposed solutions to achieve more consistency across GOV.UK.'
+    title: Content Audit Discovery – Component recommendations
+    link: https://docs.google.com/document/d/1Gb3P2lQVGjdfhBnz19FDX4coWTpbKGIpZABNnQ7iLl0/edit#heading=h.llzp42bd0b76
+    documentFormat: Google Docs
   1:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: November 2022
@@ -147,13 +148,12 @@ insights:
     documentFormat: Google Slides
   2:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: August 2022
+    date: May 2024
     description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'The content audit discovery summarised a list of inconsistencies and issues with this component and offers proposed solutions to achieve more consistency across GOV.UK.'
-    title: Content Audit Discovery – Component recommendations
-    link: https://docs.google.com/document/d/1Gb3P2lQVGjdfhBnz19FDX4coWTpbKGIpZABNnQ7iLl0/edit#heading=h.llzp42bd0b76
-    documentFormat: Google Docs
+     'A research and design project on travel advice identified that the contents list contributes to users struggling to find information they need. In the given context, working with users enabled the team to streamline the content list from 10 items down to 5. This resulted in less confusion, fewer places to look, and Emergency content info more easily found.'
+    title: Travel Advice research and design summary 2022 to 23 (pp. 8)
+    link: https://docs.google.com/presentation/d/1Qx8o2ppZgnHbXe0UAT1f5XSsTL8-QaCv/edit?usp=sharing&ouid=105832416597570443289&rtpof=true&sd=true
+    documentFormat: Google Slides
 
 # Accessibilty criteria for this component
 # List out the accessibility for this component.

--- a/docs/components/global-banner.md
+++ b/docs/components/global-banner.md
@@ -67,21 +67,21 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: May 2024
-    description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Information regarding the site-wide banner during the 2024 General Election'
-    title: Site-wide banner and featured homepage promo for the 2024 General Election
-    link: https://docs.google.com/document/d/16B-lygYgDHT-gwbjTHQaNsdx9_y2Ikdg2wiU5ekio4w/edit?usp=sharing
-    documentFormat: Google Docs
-  1:
-    # Both title and link are REQUIRED in order for this information to render on the page.
     date: May 2020
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
       'Performance of the global banner during COVID and Brexit'
     title: Global banner performance
     link: https://docs.google.com/document/d/1ltH8ydXj_W_clYimAtf1MGwQksITxz-q5Yk9E9H5yBY/edit?usp=sharing
+    documentFormat: Google Docs
+  1:
+    # Both title and link are REQUIRED in order for this information to render on the page.
+    date: May 2024
+    description:
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+      'Information regarding the site-wide banner during the 2024 General Election'
+    title: Site-wide banner and featured homepage promo for the 2024 General Election
+    link: https://docs.google.com/document/d/16B-lygYgDHT-gwbjTHQaNsdx9_y2Ikdg2wiU5ekio4w/edit?usp=sharing
     documentFormat: Google Docs
 
 # Accessibilty criteria for this component

--- a/docs/frontend-templates/answer.md
+++ b/docs/frontend-templates/answer.md
@@ -247,23 +247,14 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: September 2024
+    date: June 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'List of all the answer pages and its associated data'
-    title: 'Answer page: categorising data'
-    link: https://docs.google.com/spreadsheets/d/18osY2da0SKhSTdY9FAIhKBwCd3HMKw_jqpZS-1mu8gA/edit?usp=sharing
+      'Data on exiting from DWP answer pages'
+    title: 'Answer pages: exits'
+    link: https://docs.google.com/spreadsheets/d/1f4fSsIxkCfWiKNV9qgE_sep61f5EbKxU58wTWCsGw60/edit?gid=2140166644#gid=2140166644
     documentFormat: Google Sheets
   1:
-    # Both title and link are REQUIRED in order for this information to render on the page.
-    date: August 2024
-    description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Pages visited after an Answer page - figures are no. of sessions'
-    title: 'Answer pages: pages visited after'
-    link: https://docs.google.com/spreadsheets/d/1bxdQQvSUIfNdmuyF1Ws7RwZARIdgU9eQTN5jYrJeXkU/edit?gid=1433864911#gid=1433864911
-    documentFormat: Google Sheets
-  2:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: June 2024
     description:
@@ -272,14 +263,23 @@ insights:
     title: 'Answer pages: average engagement time/word count'
     link: https://docs.google.com/spreadsheets/d/1rJTOD69386X1lnpUpih3eXZoeX54kNB4u7dqIQA2oBg/edit?gid=132520947#gid=132520947
     documentFormat: Google Sheets
-  3:
+  2:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: June 2024
+    date: August 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Data on exiting from DWP answer pages'
-    title: 'Answer pages: exits'
-    link: https://docs.google.com/spreadsheets/d/1f4fSsIxkCfWiKNV9qgE_sep61f5EbKxU58wTWCsGw60/edit?gid=2140166644#gid=2140166644
+      'Pages visited after an Answer page - figures are no. of sessions'
+    title: 'Answer pages: pages visited after'
+    link: https://docs.google.com/spreadsheets/d/1bxdQQvSUIfNdmuyF1Ws7RwZARIdgU9eQTN5jYrJeXkU/edit?gid=1433864911#gid=1433864911
+    documentFormat: Google Sheets
+  3:
+    # Both title and link are REQUIRED in order for this information to render on the page.
+    date: September 2024
+    description:
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+      'List of all the answer pages and its associated data'
+    title: 'Answer page: categorising data'
+    link: https://docs.google.com/spreadsheets/d/18osY2da0SKhSTdY9FAIhKBwCd3HMKw_jqpZS-1mu8gA/edit?usp=sharing
     documentFormat: Google Sheets
 
 # Existing issues with this frontend template

--- a/docs/frontend-templates/finder/index.md
+++ b/docs/frontend-templates/finder/index.md
@@ -232,13 +232,13 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: August 2024
+    date: May 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Findings after the search team has improved the relevancy of site search results, and what to do next'
-    title: 'GOV.UK site search: desk research, analytics findings and product solutions'
-    link: https://docs.google.com/presentation/d/1IoupQiEuCLMc-AOEUntGeKwQPIG-cWmnleuHOgujOuI/edit?usp=sharing
-    documentFormat: Google Slides
+      'Migrating finders to Vertex in order to improve keyword search relevance'
+    title: 'Should we move finders to Google Vertex AI Search?'
+    link: https://docs.google.com/document/d/1x84j4IvpQcXy8WpG2Mx9YrO5GFZeOYOToiSzK9ax6Uk/edit?usp=sharing
+    documentFormat: Google Docs
   1:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: July 2024
@@ -250,13 +250,13 @@ insights:
     documentFormat: Google Docs
   2:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: May 2024
+    date: August 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Migrating finders to Vertex in order to improve keyword search relevance'
-    title: 'Should we move finders to Google Vertex AI Search?'
-    link: https://docs.google.com/document/d/1x84j4IvpQcXy8WpG2Mx9YrO5GFZeOYOToiSzK9ax6Uk/edit?usp=sharing
-    documentFormat: Google Docs
+      'Findings after the search team has improved the relevancy of site search results, and what to do next'
+    title: 'GOV.UK site search: desk research, analytics findings and product solutions'
+    link: https://docs.google.com/presentation/d/1IoupQiEuCLMc-AOEUntGeKwQPIG-cWmnleuHOgujOuI/edit?usp=sharing
+    documentFormat: Google Slides
 
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.

--- a/docs/frontend-templates/guide.md
+++ b/docs/frontend-templates/guide.md
@@ -295,18 +295,18 @@ insights:
     date: May 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'A spreadsheet outlining the total number of sessions in which any page from a guide was viewed.'
-    title: 'Guides: Click-thru (any page in guide)'
-    link: https://docs.google.com/spreadsheets/d/1nMZ4yU0wOhQtPwa78n4i8GKmMuCEYvQTVtKPPVCCbk0/edit?usp=sharing
+      'Data shows how many sessions included any page from each chapter and then breaks down that figure by the number of sessions for each chapter within the guide.'
+    title: 'Guides: usage across chapters'
+    link: https://docs.google.com/spreadsheets/d/1lW8AJ1HbnFv06gkDB6OUGFPZjeXQbaECWW3t4AT2YPk/edit?gid=0#gid=0
     documentFormat: Google Sheets
   1:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: May 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Data shows how many sessions included any page from each chapter and then breaks down that figure by the number of sessions for each chapter within the guide.'
-    title: 'Guides: usage across chapters'
-    link: https://docs.google.com/spreadsheets/d/1lW8AJ1HbnFv06gkDB6OUGFPZjeXQbaECWW3t4AT2YPk/edit?gid=0#gid=0
+      'A spreadsheet outlining the total number of sessions in which any page from a guide was viewed.'
+    title: 'Guides: Click-thru (any page in guide)'
+    link: https://docs.google.com/spreadsheets/d/1nMZ4yU0wOhQtPwa78n4i8GKmMuCEYvQTVtKPPVCCbk0/edit?usp=sharing
     documentFormat: Google Sheets
 
 # Existing issues with this frontend template

--- a/docs/frontend-templates/homepage.md
+++ b/docs/frontend-templates/homepage.md
@@ -225,13 +225,13 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: July 2024
+    date: April 2023
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Information regarding the design update, taken place in November 2023'
-    title: 'GOV.UK homepage'
-    link: https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/29720672/GOV.UK+homepage
-    documentFormat: Wiki entry
+      'Holistic redesign of the homepage'
+    title: Homepage Redesign Challenge
+    link: https://docs.google.com/presentation/d/13YlznozVei-m69S0hL8VAm3mMzHMSoa88EVctgDjFm0/edit?usp=sharing
+    documentFormat: Google Slides
   1:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: July 2023
@@ -243,13 +243,13 @@ insights:
     documentFormat: Google Slides
   2:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: April 2023
+    date: July 2024
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Holistic redesign of the homepage'
-    title: Homepage Redesign Challenge
-    link: https://docs.google.com/presentation/d/13YlznozVei-m69S0hL8VAm3mMzHMSoa88EVctgDjFm0/edit?usp=sharing
-    documentFormat: Google Slides
+      'Information regarding the design update, taken place in November 2023'
+    title: 'GOV.UK homepage'
+    link: https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/29720672/GOV.UK+homepage
+    documentFormat: Wiki entry
 
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.

--- a/docs/frontend-templates/mainstream-browse/index.md
+++ b/docs/frontend-templates/mainstream-browse/index.md
@@ -149,41 +149,14 @@ insights:
   # To add additional insights duplicate the the fields below (adhering to the formating) but increase the count by one integer.
   0:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: July 2023
+    date: August 2018
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Guidance on how to curate mainstream browse pages'
-    title: 'How to curate mainstream browse pages'
-    link: https://docs.google.com/presentation/d/1Kp69ojze0kbyIaE2rAyyMIB9hfOBiXNCwbQ37TxQyYQ/edit
-    documentFormat: Google Slides
-  1:
-    # Both title and link are REQUIRED in order for this information to render on the page.
-    date: August 2022
-    description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-     'Findings after A/B test with introduction of accordion component to Mainstream browse page'
-    title: 'GOV.UK Navigation mainstream browse follow-up A/B test'
-    link: https://docs.google.com/presentation/d/1poSeFuf2KMR2gzMI3A2ePT2xWi7n6QXMf6cBo8aHiZ4/edit?usp=sharing
-    documentFormat: Google Slides
-  2:
-    # Both title and link are REQUIRED in order for this information to render on the page.
-    date: June 2022
-    description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'This document sets out how the new topic pages will look and work, why we are replacing the current Mainstream Browse topic page, and what we plan to do in the future'
-    title: 'GOV.UK Navigation mainstream browse A/B test'
-    link: https://docs.google.com/presentation/d/1s1d4BYJZaZmt5J0CFORRmMTKPush88_yiT7_OR8WxHw/edit?usp=sharing
-    documentFormat: Google Slides
-  3:
-    # Both title and link are REQUIRED in order for this information to render on the page.
-    date: January 2022
-    description:
-      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'Early-thinking overhaul design of Mainstream browse page replacing miller columns and merging Specialist topics into updated topic pages'
-    title: 'Topic page design implementation'
-    link: https://docs.google.com/document/d/1MbhUjXLMUvEvqRU_w5S7RD9_wVhB3LkcdfDIxnSOz4g/edit?usp=sharing
+      'How the design sprint will run for Mainstream Browse pages'
+    title: 'Mainstream Browse design sprint'
+    link: https://docs.google.com/document/d/1aCUbrdqaCCF6mblDfddw1Wck_DmTsHADMYR-Ny-9Xw4/edit#heading=h.yo2pwekzv7t0
     documentFormat: Google Docs
-  4:
+  1:
     # Both title and link are REQUIRED in order for this information to render on the page.
     date: August 2018
     description:
@@ -192,15 +165,42 @@ insights:
     title: What is Mainstream Browse
     link: https://docs.google.com/document/d/13IkO2ZnknFDiNTn-z9E4LwCbTTN1Dnw2xcfO3iU_v9E/edit#heading=h.yw8vk47ou0r5
     documentFormat: Google Docs
-  5:
+  2:
     # Both title and link are REQUIRED in order for this information to render on the page.
-    date: August 2018
+    date: January 2022
     description:
       # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
-      'How the design sprint will run for Mainstream Browse pages'
-    title: 'Mainstream Browse design sprint'
-    link: https://docs.google.com/document/d/1aCUbrdqaCCF6mblDfddw1Wck_DmTsHADMYR-Ny-9Xw4/edit#heading=h.yo2pwekzv7t0
+      'Early-thinking overhaul design of Mainstream browse page replacing miller columns and merging Specialist topics into updated topic pages'
+    title: 'Topic page design implementation'
+    link: https://docs.google.com/document/d/1MbhUjXLMUvEvqRU_w5S7RD9_wVhB3LkcdfDIxnSOz4g/edit?usp=sharing
     documentFormat: Google Docs
+  3:
+    # Both title and link are REQUIRED in order for this information to render on the page.
+    date: June 2022
+    description:
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+      'This document sets out how the new topic pages will look and work, why we are replacing the current Mainstream Browse topic page, and what we plan to do in the future'
+    title: 'GOV.UK Navigation mainstream browse A/B test'
+    link: https://docs.google.com/presentation/d/1s1d4BYJZaZmt5J0CFORRmMTKPush88_yiT7_OR8WxHw/edit?usp=sharing
+    documentFormat: Google Slides
+  4:
+    # Both title and link are REQUIRED in order for this information to render on the page.
+    date: August 2022
+    description:
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+     'Findings after A/B test with introduction of accordion component to Mainstream browse page'
+    title: 'GOV.UK Navigation mainstream browse follow-up A/B test'
+    link: https://docs.google.com/presentation/d/1poSeFuf2KMR2gzMI3A2ePT2xWi7n6QXMf6cBo8aHiZ4/edit?usp=sharing
+    documentFormat: Google Slides
+  5:
+    # Both title and link are REQUIRED in order for this information to render on the page.
+    date: July 2023
+    description:
+      # You MUST wrap this in single quotation marks (ie. ' '), since markdown can be used to enter this information. To create a heading, use three hashes (ie. ###).
+      'Guidance on how to curate mainstream browse pages'
+    title: 'How to curate mainstream browse pages'
+    link: https://docs.google.com/presentation/d/1Kp69ojze0kbyIaE2rAyyMIB9hfOBiXNCwbQ37TxQyYQ/edit
+    documentFormat: Google Slides
 
 # Existing issues with this frontend template
 # List of all the issues that are associated with this frontend template, (1) containing the title used to describe the issue on GitHub, and (2) the link to the GitHub issue itself.


### PR DESCRIPTION
# Before
- Latest input would be recorded as the first item on the list

- It's a problem when adding new insights as you would need to update all items after that

# Proposed change
- Update the order when documenting, so the first entry will always be 0, while the latest added document will be ##

- Although this change is happening when documenting, the order that is rendered on the page will not change. Meaning the latest item will always appear on the top.