### PR TITLE
Improve accessibility of lists

### DIFF
--- a/_includes/macros/unordered-list-item-with-link.njk
+++ b/_includes/macros/unordered-list-item-with-link.njk
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro listItemsWithExternalLink(listClass, listItem) %}
-  <ul class="{{ listClass }} govuk-list">
+  <ul class="{{ listClass }} govuk-list govuk-list--bullet">
     {% for i in range(0, listItem | length ) %}
       {% if listItem[i].link and listItem[i].title %}
         <li>

--- a/_includes/partials/examples.njk
+++ b/_includes/partials/examples.njk
@@ -4,7 +4,7 @@
   <section class="doc-examples">
     {% if (examples | length ) > 1 %}
       <h2 class="doc-examples__title govuk-heading-l">Live examples</h2>
-      {{ listItemsWithExternalLink("doc-examples__list", examples) }}
+      {{ listItemsWithExternalLink("doc-examples__list govuk-list--spaced", examples) }}
       {% if contentDataLink %}
         <p class="govuk-body">Complete list of examples available and page data on <a href="{{ contentDataLink }}" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Content Data  (opens in a new tab)</a>.</p>
       {% endif %}

--- a/_includes/partials/issues.njk
+++ b/_includes/partials/issues.njk
@@ -11,7 +11,7 @@
       {% elif sectionKey === "Patterns" %}
         <h2 class="doc-issues__title govuk-heading-l">Existing issues with this pattern</h2>
       {% endif %}
-      {{ listItemsWithExternalLink("doc-issues__list", issues) }}
+      {{ listItemsWithExternalLink("doc-issues__list govuk-list--spaced", issues) }}
       {{ reportIssue("h3", "m") }}
       {% include "./instructions-report-issue.njk" %}
     {% else %}


### PR DESCRIPTION
This pull request includes changes to the `njk` files to enhance the styling of unordered lists by adding additional CSS classes. The most important changes include adding the `govuk-list--bullet` and `govuk-list--spaced` classes to various unordered lists.

Styling enhancements:

* [`_includes/macros/unordered-list-item-with-link.njk`](diffhunk://#diff-37e79718df42a58c9509c467828caca533081db15a52c5cf1850b12604cb524aL14-R14): Added the `govuk-list--bullet` class to unordered lists to display bullets.
* [`_includes/partials/examples.njk`](diffhunk://#diff-dc3eb8aec1ce161afd405e5227febe4efc33272f25d6a71e4f4680085147eacaL7-R7): Added the `govuk-list--spaced` class to the examples list to increase spacing between items.
* [`_includes/partials/issues.njk`](diffhunk://#diff-49a1b25edae5465d71c74e4e952b4bd6efa3523bf39f212c37589d49804da7ebL14-R14): Added the `govuk-list--spaced` class to the issues list to increase spacing between items.