### PR TITLE
Reveal sub-navigation

### DIFF
--- a/_includes/partials/sub-navigation.njk
+++ b/_includes/partials/sub-navigation.njk
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-one-quarter-from-desktop">
   {{ xGovukSubNavigation({
-    items: collections.ordered | eleventyNavigation(sectionKey or options.homeKey) | itemsFromNavigation(page.url, { pathPrefix: options.pathPrefix })
+    items: collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | itemsFromNavigation(page.url, { pathPrefix: options.pathPrefix })
   }) }}
 </div>


### PR DESCRIPTION
Since upgrading to Version 6.7.2 the sub-navigation has gone missing.

This is meant to resolve this issue.