### PR TITLE
Change Answer rendering app to frontend

### DIFF
--- a/docs/frontend-templates/answer.md
+++ b/docs/frontend-templates/answer.md
@@ -114,7 +114,7 @@ renderingApp:
     # government frontend
     # smart answers
     # static
-  government frontend
+  frontend
 
 # Components that make-up this frontend template
 # List out all the components that make-up this frontend template, by (1) providing the name of the component, (2) a link to the documentation for said component, (3) how is this component generated on the page and (4) the associated publishing input fields within the publishing app.


### PR DESCRIPTION
Answer document is moved over from `government-frontend` to `frontend` and so the rendering app in the guide is updated accordingly.

Trello: https://trello.com/c/Dv4uSqX0/525-move-answer-from-government-frontend-to-frontend