### PR TITLE
Update the community page

### DIFF
--- a/docs/community/get-involved.md
+++ b/docs/community/get-involved.md
@@ -9,7 +9,7 @@ details:
   <ol class="govuk-list govuk-list--number govuk-heading-m">
     <li class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Join the conversation on Slack</h2>
-      <p class="govuk-body">To get involved in current conversations about the library <a class="govuk-link" href="https://join.slack.com/share/enQtNzc0ODgwMDM4ODcyMC04YjhkN2U2OTdkMmVlMjdkNTI5ZmYxOGE4Y2QwNGI4ZmFjZWU4ZGQzNTEzNzk4MGQ2YjY2YzU5NDcxMDc3YmM5" rel="noopener noreferrer" target="_blank">join our Slack channel (opens in a new tab)</a>. Here you can find out about what the community is up to and offer or ask for support.</p>
+      <p class="govuk-body">To get involved or if you have any questions join <strong>#community-govuk-publishing-design-guide</strong> Slack channel.</p>
     </li>
     <li class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback on GitHub</h2>

--- a/docs/community/get-involved.md
+++ b/docs/community/get-involved.md
@@ -24,11 +24,6 @@ details:
       <p class="govuk-body">Each piece of documentation aims to include information and insights from many disciplines. Add what you know or help us dig out documents and data on older designs and add them to the documentation on GitHub.</p>
     </li>
     <li class="govuk-!-margin-bottom-6">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Join a workshop</h2>
-      <p class="govuk-body">We regularly run cross-community workshops to document together.</p>
-      <p class="govuk-body">We also run sessions to get people set up and trained in GitHub. If you would like to attend, contact us via Slack.</p>
-    </li>
-    <li class="govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contribute new documentation </h2>
       <p class="govuk-body">Take a bigger role as a contributor by adding a new component, pattern, or frontend template to the Publishing Design Guide.</p>
       <p class="govuk-body">You might have something you have worked on that you are well placed to document. Alternatively, pick something from our <a class="govuk-link" href="https://trello.com/invite/b/66c32aba108fc7e90e7b4d27/ATTIf9cb80c70723c20e7297e873bd09db260C186DF6/govuk-design-library-governance" rel="noopener noreferrer" target="_blank">backlog (opens in a new tab)</a> of designs we have prioritised to be documented.</p>


### PR DESCRIPTION
# What
The community page in the Publishing Design Guide is out of date due to programme and organization priorities.
## Proposed changes
- Link to a new Slack Channel for GOVUKers to ask anything about the design guide
- Removal of workshops

#Why
Currently doesn’t reflect the current situation.