### PR TITLE
Remove contacts admin from template guidance

### DIFF
--- a/docs/frontend-templates/*frontend-template-documentation-template.md
+++ b/docs/frontend-templates/*frontend-template-documentation-template.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/answer.md
+++ b/docs/frontend-templates/answer.md
@@ -88,7 +88,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/calendar.md
+++ b/docs/frontend-templates/calendar.md
@@ -97,7 +97,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/completed-transaction.md
+++ b/docs/frontend-templates/completed-transaction.md
@@ -105,7 +105,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/detailed-guide.md
+++ b/docs/frontend-templates/detailed-guide.md
@@ -107,7 +107,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/document-collections.md
+++ b/docs/frontend-templates/document-collections.md
@@ -128,7 +128,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/case-studies-finder.md
+++ b/docs/frontend-templates/finder/case-studies-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/departments-agencies-public-bodies-finder.md
+++ b/docs/frontend-templates/finder/departments-agencies-public-bodies-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/groups-finder.md
+++ b/docs/frontend-templates/finder/groups-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/hmrc-contacts-finder.md
+++ b/docs/frontend-templates/finder/hmrc-contacts-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/index.md
+++ b/docs/frontend-templates/finder/index.md
@@ -178,7 +178,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/people-finder.md
+++ b/docs/frontend-templates/finder/people-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/search.md
+++ b/docs/frontend-templates/finder/search.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/specialist-document-finder.md
+++ b/docs/frontend-templates/finder/specialist-document-finder.md
@@ -169,7 +169,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/statistical-data-sets-finder.md
+++ b/docs/frontend-templates/finder/statistical-data-sets-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/supergroup-finder.md
+++ b/docs/frontend-templates/finder/supergroup-finder.md
@@ -118,7 +118,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/topical-events-finder.md
+++ b/docs/frontend-templates/finder/topical-events-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/finder/world-organisation-finder.md
+++ b/docs/frontend-templates/finder/world-organisation-finder.md
@@ -70,7 +70,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/guide.md
+++ b/docs/frontend-templates/guide.md
@@ -88,7 +88,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/homepage.md
+++ b/docs/frontend-templates/homepage.md
@@ -81,7 +81,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/mainstream-browse/index.md
+++ b/docs/frontend-templates/mainstream-browse/index.md
@@ -95,7 +95,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/mainstream-browse/level-one.md
+++ b/docs/frontend-templates/mainstream-browse/level-one.md
@@ -88,7 +88,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/mainstream-browse/level-two.md
+++ b/docs/frontend-templates/mainstream-browse/level-two.md
@@ -79,7 +79,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/smart-answer/github-smart-answer.md
+++ b/docs/frontend-templates/smart-answer/github-smart-answer.md
@@ -97,7 +97,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/smart-answer/index.md
+++ b/docs/frontend-templates/smart-answer/index.md
@@ -86,7 +86,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/smart-answer/simple-smart-answer.md
+++ b/docs/frontend-templates/smart-answer/simple-smart-answer.md
@@ -97,7 +97,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/special-route.md
+++ b/docs/frontend-templates/special-route.md
@@ -91,7 +91,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/step-by-step-nav.md
+++ b/docs/frontend-templates/step-by-step-nav.md
@@ -118,7 +118,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/topical-events/about.md
+++ b/docs/frontend-templates/topical-events/about.md
@@ -92,7 +92,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/topical-events/index.md
+++ b/docs/frontend-templates/topical-events/index.md
@@ -103,7 +103,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager

--- a/docs/frontend-templates/transaction.md
+++ b/docs/frontend-templates/transaction.md
@@ -88,7 +88,6 @@ publishingApp:
   # The GOV.UK [browser extension](https://github.com/alphagov/govuk-browser-extension) can help indentify the publishing app associated with adding content to this frontend template.
   # Publishing app options:
     # collections publisher
-    # contacts admin
     # content publisher
     # content tagger
     # local links manager


### PR DESCRIPTION
With the removal of Contacts Admin #245 be good to remove any mention of it in the code base.