### PR TITLE
Apply GOV.UK rebrand

### DIFF
--- a/docs/assets/styles.scss
+++ b/docs/assets/styles.scss
@@ -1,5 +1,5 @@
 // Use GOV.UK Frontend
-@use "pkg:govuk-frontend/dist/govuk";
+@use "pkg:govuk-frontend/dist/govuk/settings";
 
 // Use GOV.UK Eleventy Plugin components
 @use "pkg:@x-govuk/govuk-eleventy-plugin";
@@ -11,5 +11,5 @@
 .x-govuk-masthead__title,
 .x-govuk-masthead__description
  {
-    color: #0b0c0c;
+    color: settings.$govuk-text-colour;
 }

--- a/docs/assets/styles.scss
+++ b/docs/assets/styles.scss
@@ -5,5 +5,11 @@
 @use "pkg:@x-govuk/govuk-eleventy-plugin";
 
 .x-govuk-masthead {
-    background-color: #263135;
+    background-color: #d2e2f1;
+}
+
+.x-govuk-masthead__title,
+.x-govuk-masthead__description
+ {
+    color: #0b0c0c;
 }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -30,6 +30,7 @@ export default function(eleventyConfig) {
     header: {
       productName: "Publishing Design Guide"
     },
+    rebrand: true,
     serviceNavigation: {
       navigation: [
         {


### PR DESCRIPTION
### Context
- GOV.UK rebrand kicks off on June 25.
- Need to update the custom color to match with L1 Mainstream pages banner background color.

| Before | After |
| ----- | ----- |
| ![design-guide publishing service gov uk_(iPad Air)](https://github.com/user-attachments/assets/13e66a4d-f39d-40b3-949c-c80fbfc965c5) | ![localhost_8080_(iPad Air)](https://github.com/user-attachments/assets/0218f9b1-b179-4aab-997a-45cd2f06b01a) |
