### PR TITLE
Remove rollup's commonJS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "dependencies": {
         "@11ty/eleventy": "^3.1.1",
         "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^28.0.5",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@x-govuk/govuk-eleventy-plugin": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@11ty/eleventy": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-commonjs": "^28.0.5",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@x-govuk/govuk-eleventy-plugin": "^7.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from '@rollup/plugin-babel'
-import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import { defineConfig } from 'rollup'
@@ -20,7 +19,6 @@ export default defineConfig({
   plugins: [
     terser(),
     resolve(),
-    commonjs(),
     babel({
       babelHelpers: 'bundled'
     })


### PR DESCRIPTION
# Context
- Since updating to the latest version of 11ty and X-GOV plugin, I've taken the liberty to update all CommonJS files to ESM.
- As a result, the Rollup plugin to convert CommonJS to ESM is no longer necessary.