### PR TITLE
Update detailed_guide rendering app to frontend

### DIFF
--- a/docs/frontend-templates/detailed-guide.md
+++ b/docs/frontend-templates/detailed-guide.md
@@ -132,7 +132,7 @@ renderingApp:
     # government frontend
     # smart answers
     # static
-  government frontend
+  frontend
 
 # Components that make-up this frontend template
 # List out all the components that make-up this frontend template, by (1) providing the name of the component, (2) a link to the documentation for said component, (3) how is this component generated on the page and (4) the associated publishing input fields within the publishing app.


### PR DESCRIPTION
`Detailed_guide` document is migrated from `government-frontend` to `frontend` and so the rendering app in the guide is updated accordingly.

[Trello card](https://trello.com/c/8HsfHbJ6)