### PR TITLE
280 add description to glossary terms

### DIFF
--- a/docs/glossary/attribute.md
+++ b/docs/glossary/attribute.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Attribute
+description: Attributes describe the characteristics of a content type, creating consistent structure to make content easier to understand, manage, display and reuse.
 details:
   'Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags.
   

--- a/docs/glossary/attribute.md
+++ b/docs/glossary/attribute.md
@@ -4,23 +4,31 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Attribute
+details:
+  'Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags.
+  
+
+  Attributes create consistent structure to make it easier to understand, manage, display and reuse content.
+
+
+  Attributes can be:
+  
+  - core content written by a person — for example, title, description, biography
+
+  - metadata with structured values defined by the system or chosen from a predefined list — for example, date published, topic or country
+  
+
+  Attributes are captured at a conceptual level in the [content model](/glossary/content-model).
+  
+
+  Attributes become properties when the model is translated into a [content schema](/glossary/content-schema).
+  
+
+  ## Synonyms
+  
+  - Property — a term used in our schemas and codebase
+
+  - Field — a term used by publishers to describe the input space in a Content Management System'
 theme: Information layer
 order: 4
 ---
-Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags. 
-
-Attributes create consistent structure to make it easier to understand, manage, display and reuse content.
-
-Attributes can be:
-
-- core content written by a person – for example, title, description, biography 
-- metadata with structured values defined by the system or chosen from a predefined list – for example, date published, topic or country 
-
-Attributes are captured at a conceptual level in the [content model](/glossary/content-model). 
-
-Attributes become properties when the model is translated into a [content schema](/glossary/content-schema). 
-
-## Synonyms
-
-- Property – a term used in our schemas and codebase
-- Field – a term used by publishers to describe the input space in a Content Management System

--- a/docs/glossary/component.md
+++ b/docs/glossary/component.md
@@ -4,18 +4,23 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Component
+details:
+  'Components are reusable parts of a user interface. They are pre-built, core elements that allow designers and developers to build consistent pages on GOV.UK (source: [GOV.UK Design System](https://design-system.service.gov.uk/components/)).
+  
+
+  Components are the building blocks of a user interface. Things like buttons, forms or navigation menus. For reference, this is the [GOV.UK Component Guide](https://components.publishing.service.gov.uk/component-guide)
+  
+  
+  ## Non-preferred terms
+  
+  - Block
+  
+  - Module
+  
+  
+  ## Do not confuse with
+  
+  [Container](/glossary/container)'
 theme: Presentation layer
 order: 4
 ---
-Components are reusable parts of a user interface. They are pre-built, core elements that allow designers and developers to build consistent pages on GOV.UK (source: [GOV.UK Design System](https://design-system.service.gov.uk/components/)).
-
-Components are the building blocks of a user interface. Things like buttons, forms or navigation menus. For reference, this is the [GOV.UK Component Guide](https://components.publishing.service.gov.uk/component-guide)
-
-## Non-preferred terms
-
-- Block
-- Module
-
-## Do not confuse with
-
-[Container](/glossary/container)

--- a/docs/glossary/component.md
+++ b/docs/glossary/component.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Component
+description: Components are reusable parts of a user interface that serve as pre-built, core elements for building consistent pages.
 details:
   'Components are reusable parts of a user interface. They are pre-built, core elements that allow designers and developers to build consistent pages on GOV.UK (source: [GOV.UK Design System](https://design-system.service.gov.uk/components/)).
   

--- a/docs/glossary/container.md
+++ b/docs/glossary/container.md
@@ -4,23 +4,30 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Container
+details:
+  '<div class="govuk-inset-text">
+    Note: Currently in development.
+  </div>
+  
+
+  Containers will be flexible sections within a broader template. They’ll give publishers more choice over how they display their content and how they structure the user interface.
+  
+  
+  Containers are intended to be populated with content and metadata attributes, user interface (UI) components and reusable content blocks.
+  
+  
+  ## Non-preferred terms
+  
+  - Block
+
+  - Section
+
+  - Module
+  
+  
+  ## Do not confuse with
+
+  [Component](/glossary/component)'
 theme: Presentation layer
 order: 3
 ---
-<div class="govuk-inset-text">
-  Note: Currently in development.
-</div>
-
-Containers will be flexible sections within a broader template. They'll give publishers more choice over how they display their content and how they structure the user interface.
-
-Containers are intended to be populated with content and metadata attributes, user interface (UI) components and reusable content blocks.
-
-## Non-preferred terms
-
-- Block
-- Section
-- Module
-
-## Do not confuse with
-
-[Component](/glossary/component)

--- a/docs/glossary/container.md
+++ b/docs/glossary/container.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Container
+description: Containers are flexible sections within templates that give publishers choice over content display and user interface structure.
 details:
   '<div class="govuk-inset-text">
     Note: Currently in development.

--- a/docs/glossary/content-model.md
+++ b/docs/glossary/content-model.md
@@ -4,19 +4,25 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content model
+details:
+  'The content model is the output of doing content modelling.
+  
+
+  Content modelling divides content into its smallest reasonable pieces. Organising and classifying content so it can be understood and used by computers and humans.
+  
+  
+  Content modelling defines:
+  
+  - the different kinds of content you have (or could have) in your domain
+  
+  - the [attributes](/glossary/attribute) that make up each content type
+  
+  - the relationships between the [content types](/glossary/content-type) and how they work together
+
+
+  ## Do not confuse with
+  
+  Domain model — maps the core concepts and relationships of an organisation’s operating context'
 theme: Information layer
 order: 1
 ---
-The content model is the output of doing content modelling.
-
-Content modelling divides content into its smallest reasonable pieces. Organising and classifying content so it can be understood and used by computers and humans.
-
-Content modelling defines:
-
-- the different kinds of content you have (or could have) in your domain
-- the [attributes](/glossary/attribute) that make up each content type
-- the relationships between the [content types](/glossary/content-type) and how they work together
-
-## Do not confuse with
-
-Domain model – maps the core concepts and relationships of an organisation’s operating context

--- a/docs/glossary/content-model.md
+++ b/docs/glossary/content-model.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content model
+description: Content modelling organizes and classifies content into its smallest reasonable pieces so it can be understood and used by both computers and humans.
 details:
   'The content model is the output of doing content modelling.
   

--- a/docs/glossary/content-schema.md
+++ b/docs/glossary/content-schema.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content schema
+description: Content schema defines the underlying structure and properties of a piece of content on GOV.UK.
 details:
   'A GOV.UK content schema is a JSON schema that defines the underlying structure and properties of a piece of content.
   

--- a/docs/glossary/content-schema.md
+++ b/docs/glossary/content-schema.md
@@ -4,18 +4,23 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content schema
+details:
+  'A GOV.UK content schema is a JSON schema that defines the underlying structure and properties of a piece of content.
+  
+
+  The schema also contains data on the relationships with other schemas, classification systems and content types.
+  
+  
+  ## Non-preferred term
+
+  Content format
+  
+  
+  ## Do not confuse with
+
+  - [Content type](/glossary/content-type)
+
+  - [Template](/glossary/template) '
 theme: Information layer
 order: 2
 ---
-A GOV.UK content schema is a JSON schema that defines the underlying structure and properties of a piece of content.
-
-The schema also contains data on the relationships with other schemas, classification systems and content types.
-
-## Non-preferred term
-
-Content format
-
-## Do not confuse with
-
-- [Content type](/glossary/content-type)
-- [Template](/glossary/template) 

--- a/docs/glossary/content-type.md
+++ b/docs/glossary/content-type.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content type
+description: Content types provide a framework for structuring and categorizing content.
 details:
   'Content types are a way of organising content that has a common structure and purpose. For example, if you had a group of content items that are all types of speech, you’d create a "speech" content type so they share a consistent structure and classification.
   

--- a/docs/glossary/content-type.md
+++ b/docs/glossary/content-type.md
@@ -4,24 +4,31 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content type
+details:
+  'Content types are a way of organising content that has a common structure and purpose. For example, if you had a group of content items that are all types of speech, you’d create a "speech" content type so they share a consistent structure and classification.
+  
+  
+  Information architects model the attributes that make up the content types (including core content or metadata) and the relationships between content types.
+  
+  
+  In GOV.UK’s tech stack, the content type is coded into the broader content schema.
+  
+  
+  ## Synonym
+  
+  Document type — term used in our code and developer documentation (co-exists with content type)
+  
+
+  ## Non-preferred term
+  
+  Content format
+  
+  
+  ## Do not confuse with
+  
+  - [Content schema](/glossary/content-schema)
+  
+  - [Template](/glossary/template)'
 theme: Information layer
 order: 3
 ---
-Content types are a way of organising content that has a common structure and purpose. For example, if you had a group of content items that are all types of speech, you'd create a 'speech' content type so they share a consistent structure and classification.
-
-Information architects model the attributes that make up the content types (including core content or metadata) and the relationships between content types.
-
-In GOV.UK's tech stack, the content type is coded into the broader content schema.
-
-## Synonym 
-
-Document type – term used in our code and developer documentation (co-exists with content type)
-
-## Non-preferred term
-
-Content format
-
-## Do not confuse with
-
-- [Content schema](/glossary/content-schema)
-- [Template](/glossary/template) 

--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -4,7 +4,7 @@ sectionKey: Glossary
 title: Glossary
 description: This glossary (or controlled vocabulary) captures the preferred and non-preferred terms we use when working on the GOV.UK platform.
 details:
-  "It covers terminology in the:
+  'It covers terminology in the:
 
   - backend information layer – content models, content schemas and content types
   
@@ -21,7 +21,7 @@ details:
   
   - supports onboarding for new team members
 
-  - keeps systems coherent as they grow"
+  - keeps systems coherent as they grow'
 image:
   src: /assets/images/glossary.svg
   alt: Three vertical stacks of colorful blocks, each topped with the GOV.UK crown as its connector.

--- a/docs/glossary/layout.md
+++ b/docs/glossary/layout.md
@@ -4,14 +4,18 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Layout
+details:
+  'A layout is the high-level arrangement of [components](/glossary/component) and content in a user interface. The term encompasses hierarchy, alignment, spacing and screen sizes.
+  
+  
+  [Common GOV.UK layouts](https://design-system.service.gov.uk/styles/layout/#common-layouts) include the single column, two-thirds and one-third, and two-thirds.
+  
+  
+  ## Non-preferred terms
+  
+  - Grid
+
+  - Pattern'
 theme: Presentation layer
 order: 2
 ---
-A layout is the high-level arrangement of [components](/glossary/component) and content in a user interface. The term encompasses hierarchy, alignment, spacing and screen sizes.
-
-[Common GOV.UK layouts](https://design-system.service.gov.uk/styles/layout/#common-layouts) include the single column, two-thirds and one-third, and two-thirds.
-
-## Non-preferred terms
-
-- Grid
-- Pattern

--- a/docs/glossary/layout.md
+++ b/docs/glossary/layout.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Layout
+description: A layout defines how components and content are organized and positioned within a user interface.
 details:
   'A layout is the high-level arrangement of [components](/glossary/component) and content in a user interface. The term encompasses hierarchy, alignment, spacing and screen sizes.
   

--- a/docs/glossary/template.md
+++ b/docs/glossary/template.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Template
+description: A template defines the structure and visual elements for a specific content type.
 details:
   'A template contains the layouts and components for a content type.
   

--- a/docs/glossary/template.md
+++ b/docs/glossary/template.md
@@ -4,17 +4,22 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Template
+details:
+  'A template contains the layouts and components for a content type.
+  
+  
+  ## Non-preferred terms
+  
+  - Format
+
+  - Layout
+  
+  
+  ## Do not confuse with
+  
+  - [Content type](/glossary/content-type)
+
+  - [Content schema](/glossary/content-schema)'
 theme: Presentation layer
 order: 1
 ---
-A template contains the layouts and components for a content type.
-
-## Non-preferred terms
-
-- Format
-- Layout
-
-## Do not confuse with
-
-- [Content type](/glossary/content-type)
-- [Content schema](/glossary/content-schema)

--- a/docs/glossary/using-this-glossary.md
+++ b/docs/glossary/using-this-glossary.md
@@ -4,6 +4,7 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Using this glossary
+description: Learn about preferred terms, synonyms, and non-preferred terms to effectively navigate this glossary.
 details:
   'Here’s a summary of the terminology used in this glossary:
 

--- a/docs/glossary/using-this-glossary.md
+++ b/docs/glossary/using-this-glossary.md
@@ -4,10 +4,13 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Using this glossary
+details:
+  'Here’s a summary of the terminology used in this glossary:
+
+  - preferred term — the agreed word to use
+
+  - synonyms — words that mean the same as the preferred term and are okay to use in certain contexts
+
+  - non-preferred term — words that should not be used, for example because they have an existing meaning or cause unnecessary confusion for users'
 order: 0
 ---
-Here's a summary of the terminology used in this glossary:
-
-- preferred term – the agreed word to use
-- synonyms – words that mean the same as the preferred term and are okay to use in certain contexts
-- non-preferred term – words that should not be used, for example because they have an existing meaning or cause unnecessary confusion for users


### PR DESCRIPTION
Add a description to Glossary terms. On the page itself (below the page title) and within the meta description.