### PR TITLE
Couple sections that were missed during the original udpate

### DIFF
--- a/_includes/macros/report-issue.njk
+++ b/_includes/macros/report-issue.njk
@@ -1,3 +1,3 @@
 {% macro reportIssue(headingLevel, headingClass) %}
-  <{{ headingLevel }} class="govuk-heading-{{ headingClass }} doc-report">How to report an issue</{{ headingLevel }}>
+  <{{ headingLevel }} id="how-to-report-an-issue" tabindex="-1" class="govuk-heading-{{ headingClass }} govuk-!-padding-top-4">How to report an issue</{{ headingLevel }}>
 {% endmacro %}

--- a/_includes/partials/insights.njk
+++ b/_includes/partials/insights.njk
@@ -1,7 +1,7 @@
 {% if insights[0].description %}
   <section class="doc-evidence-and-insights">
     <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--l">History and insights</caption>
+      <caption id="history-and-insights" tabindex="-1" class="govuk-table__caption govuk-table__caption--l govuk-!-padding-top-4">History and insights</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Date</th>


### PR DESCRIPTION
Missed a couple sections when the works of updating spacing for headings was originally done.

Also taken the liberty to include `ids` and `tabindex` 