### PR TITLE
280 add description to glossary terms

### DIFF
--- a/docs/glossary/attribute.md
+++ b/docs/glossary/attribute.md
@@ -4,12 +4,10 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Attribute
+description: Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags.
 details:
-  'Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags.
+  'Attributes create consistent structure to make it easier to understand, manage, display and reuse content.
   
-
-  Attributes create consistent structure to make it easier to understand, manage, display and reuse content.
-
 
   Attributes can be:
   

--- a/docs/glossary/attribute.md
+++ b/docs/glossary/attribute.md
@@ -4,10 +4,10 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Attribute
-description: Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body, location and tags.
+description: Attributes describe the characteristics of a content type. For example, a news article has a title, summary, author, date, body and location.
 details:
   'Attributes create consistent structure to make it easier to understand, manage, display and reuse content.
-  
+
 
   Attributes can be:
   
@@ -28,7 +28,7 @@ synonym:
   1:
     title: Field
     link:
-    definition: a term used by publishers to describe the input space in a Content Management System
+    definition: a term used by publishers to describe the input space in a content management system
 nonPreferred:
   0:
     title:

--- a/docs/glossary/component.md
+++ b/docs/glossary/component.md
@@ -4,11 +4,17 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Component
+description: Components are pre-built, core elements that allow teams to build consistent pages on GOV.UK. 
 details:
-  'Components are reusable parts of a user interface. They are pre-built, core elements that allow designers and developers to build consistent pages on GOV.UK (source: [GOV.UK Design System](https://design-system.service.gov.uk/components/)).
-  
+  'Components are the reusable building blocks of the user interface. Things like buttons, forms and navigation menus. 
 
-  Components are the building blocks of a user interface. Things like buttons, forms or navigation menus. For reference, this is the [GOV.UK Component Guide](https://components.publishing.service.gov.uk/component-guide)'
+  
+  For more information on components, see the:
+
+  - [GOV.UK Design System](https://design-system.service.gov.uk/components/)
+
+  - [GOV.UK Component Guide](https://components.publishing.service.gov.uk/component-guide)'
+
 synonym:
   0:
     title:

--- a/docs/glossary/container.md
+++ b/docs/glossary/container.md
@@ -4,16 +4,14 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Container
+description: Containers will be flexible sections within a template. They'll contain content and metadata attributes, user interface components and reusable content blocks.
 details:
   '<div class="govuk-inset-text">
     Note: Currently in development.
   </div>
   
 
-  Containers will be flexible sections within a broader template. They’ll give publishers more choice over how they display their content and how they structure the user interface.
-  
-  
-  Containers are intended to be populated with content and metadata attributes, user interface (UI) components and reusable content blocks.'
+  Containers are intended to give publishers more choice in how they display their content and how they structure the user experience.'
 synonym:
   0:
     title:

--- a/docs/glossary/content-model.md
+++ b/docs/glossary/content-model.md
@@ -4,20 +4,22 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content model
+description: The content model is the output of doing content modelling. Content modelling organises, classifies and describes content so it can be understood and used by humans and computers.  
 details:
-  'The content model is the output of doing content modelling.
+  'Content modelling divides content into smaller pieces to support content reuse, findability and consistency. 
   
+  
+  Giving content structure at a more granular level than the ‘page’ enables better search, knowledge organisation and AI outcomes.
 
-  Content modelling divides content into its smallest reasonable pieces. Organising and classifying content so it can be understood and used by computers and humans.
-  
-  
+
+
   Content modelling defines:
   
-  - the different kinds of content you have (or could have) in your domain
+  - the different [content types](/glossary/content-type) you have (or could have) in your domain
   
   - the [attributes](/glossary/attribute) that make up each content type
   
-  - the relationships between the [content types](/glossary/content-type) and how they work together'
+  - the relationships between the content types'
 synonym:
   0:
     title:
@@ -32,7 +34,7 @@ doNotConfuse:
     0:
       title: Domain model
       link:
-      definition: maps the core concepts and relationships of an organisation’s operating context
+      definition: this maps an organisation's core concepts and the relationships between them
 theme: Information layer
 order: 1
 ---

--- a/docs/glossary/content-schema.md
+++ b/docs/glossary/content-schema.md
@@ -4,11 +4,9 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content schema
+description: A GOV.UK content schema is a JSON schema that defines the underlying structure and properties of a piece of content.
 details:
-  'A GOV.UK content schema is a JSON schema that defines the underlying structure and properties of a piece of content.
-  
-
-  The schema also contains data on the relationships with other schemas, classification systems and content types.'
+  'The schema contains data on the content type, and the relationships with other schemas and GOV.UK classification systems.'
 synonym:
   0:
     title:

--- a/docs/glossary/content-type.md
+++ b/docs/glossary/content-type.md
@@ -4,11 +4,12 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Content type
+description: Content types provide a reusable stencil for organising content that has a common structure and purpose. 
 details:
-  'Content types are a way of organising content that has a common structure and purpose. For example, if you had a group of content items that are all types of speech, you’d create a "speech" content type so they share a consistent structure and classification.
+  'For example, GOV.UK has content types for things like speeches, news articles, guidance and consultations. These content types provide the content items with consistent classification and structure.
+
   
-  
-  Information architects model the attributes that make up the content types (including core content or metadata) and the relationships between content types.
+  Content types contain [attributes](/glossary/attribute) — these can be core content or metadata. 
   
   
   In GOV.UK’s tech stack, the content type is coded into the broader content schema.'

--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -6,12 +6,12 @@ description: This glossary (or controlled vocabulary) captures the preferred and
 details:
   'It covers terminology in the:
 
-  - backend information layer – content models, content schemas and content types
+  - backend information layer — for example, content type or attribute
   
-  - frontend presentation layer – templates, layouts, components and containers
+  - frontend presentation layer — for example, template or component 
 
 
-  The benefits of having a shared vocabulary are:
+  The benefits of having a shared vocabulary are that it:
 
   - creates collective understanding and consistency
   

--- a/docs/glossary/layout.md
+++ b/docs/glossary/layout.md
@@ -4,11 +4,12 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Layout
+description: A layout is the high-level arrangement of [components](/glossary/component) and content in a user interface. 
 details:
-  'A layout is the high-level arrangement of [components](/glossary/component) and content in a user interface. The term encompasses hierarchy, alignment, spacing and screen sizes.
+  'The layout encompasses hierarchy, alignment, spacing and screen sizes. 
   
   
-  [Common GOV.UK layouts](https://design-system.service.gov.uk/styles/layout/#common-layouts) include the single column, two-thirds and one-third, and two-thirds.'
+  [Common GOV.UK layouts](https://design-system.service.gov.uk/styles/layout/#common-layouts) are single column, two-thirds and one-third, and two-thirds.'
 synonym:
   0:
     title:

--- a/docs/glossary/template.md
+++ b/docs/glossary/template.md
@@ -4,8 +4,9 @@ sectionKey: Glossary
 eleventyNavigation:
   parent: Glossary
 title: Template
+description: A template contains the layouts and components for a content type.
 details:
-  'A template contains the layouts and components for a content type.'
+
 synonym:
   0:
     title:


### PR DESCRIPTION
- Reworked the content in the details field to create a description for every glossary entry 
- Removed mention of specific job titles - e.g. Information architects, designers and developers to make it more universally applicable
- Made the glossary landing page more future proof - by only showing 2 examples after the information layer and presentation layer bullet points