### PR TITLE
Rename 'doNotConfuse' to 'relatedTerm' in glossary documents for clarity

### DIFF
--- a/_includes/layouts/glossary-documentation.njk
+++ b/_includes/layouts/glossary-documentation.njk
@@ -22,9 +22,9 @@
           {{ glossaryListItems(nonPreferred, 'Non-preferred term', 'non-preferred') }}
         </section>
       {% endif %}
-      {% if doNotConfuse[0].title %}
-        <section class="doc-do-not-confuse">
-          {{ glossaryListItems(doNotConfuse, 'Do not confuse with the term', 'do-not-confuse') }}
+      {% if relatedTerm[0].title %}
+        <section class="doc-related-term">
+          {{ glossaryListItems(relatedTerm, 'Related term', 'related-term') }}
         </section>
       {% endif %}
       {% if image.src %}

--- a/docs/glossary/attribute.md
+++ b/docs/glossary/attribute.md
@@ -34,7 +34,7 @@ nonPreferred:
     title:
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title:
       link:

--- a/docs/glossary/component.md
+++ b/docs/glossary/component.md
@@ -29,7 +29,7 @@ nonPreferred:
     title: Module
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Container
       link: /glossary/container

--- a/docs/glossary/container.md
+++ b/docs/glossary/container.md
@@ -30,7 +30,7 @@ nonPreferred:
     title: Module
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Component
       link: /glossary/component

--- a/docs/glossary/content-model.md
+++ b/docs/glossary/content-model.md
@@ -29,7 +29,7 @@ nonPreferred:
     title:
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Domain model
       link:

--- a/docs/glossary/content-schema.md
+++ b/docs/glossary/content-schema.md
@@ -17,7 +17,7 @@ nonPreferred:
     title: Content format
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Content type
       link: /glossary/content-type

--- a/docs/glossary/content-type.md
+++ b/docs/glossary/content-type.md
@@ -23,7 +23,7 @@ nonPreferred:
     title: Content format
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Content schema
       link: /glossary/content-schema

--- a/docs/glossary/layout.md
+++ b/docs/glossary/layout.md
@@ -24,7 +24,7 @@ nonPreferred:
     title: Pattern
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title:
       link:

--- a/docs/glossary/template.md
+++ b/docs/glossary/template.md
@@ -16,7 +16,7 @@ nonPreferred:
     title: Format
     link:
     definition:
-doNotConfuse:
+relatedTerm:
     0:
       title: Content type
       link: /glossary/content-type

--- a/docs/glossary/using-this-glossary.md
+++ b/docs/glossary/using-this-glossary.md
@@ -13,7 +13,7 @@ details:
 
   - non-preferred terms — terms that should not be used, for example because they have an existing meaning or cause unnecessary confusion for users
 
-  - do not confuse with terms — terms that are closely related to the preferred term but are not the same
+  - related terms — terms that are closely related to the preferred term but are not the same
 
   ## Get involved
   


### PR DESCRIPTION
Literally as it says on the tin