### PR TITLE
hide insights link and document format

### DIFF
--- a/_includes/partials/insights.njk
+++ b/_includes/partials/insights.njk
@@ -6,8 +6,8 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Date</th>
           <th scope="col" class="govuk-table__header">Description</th>
-          <th scope="col" class="govuk-table__header">Document</th>
-          <th scope="col" class="govuk-table__header">Format</th>
+          {# <th scope="col" class="govuk-table__header">Document</th> #}
+          {# <th scope="col" class="govuk-table__header">Format</th> #}
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -16,12 +16,12 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">{{ insights[i].date }}</th>
               <td class="govuk-table__cell">{{ insights[i].description | markdown }}</td>
-              <td class="govuk-table__cell">
+              {# <td class="govuk-table__cell">
                 {% if insights[i].link and insights[i].title %}
                   <a href="{{ insights[i].link }}" class="govuk-link" rel="noopener noreferrer" target="_blank">{{ insights[i].title }} (opens in a new tab)</a>
                 {% endif %}
-              </td>
-              <td class="govuk-table__cell">{{ insights[i].documentFormat }}</td>
+              </td> #}
+              {#<td class="govuk-table__cell">{{ insights[i].documentFormat }}</td>#}
             </tr>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
Hiding the insights link and document format column until we decide how best to share this content

before:
<img width="1035" height="1045" alt="before" src="https://github.com/user-attachments/assets/cbdda0b6-acac-41e9-b417-09bfdfa61274" />

after:
<img width="951" height="691" alt="after" src="https://github.com/user-attachments/assets/ba47240c-e7d8-4209-983b-22b94e3513c1" />

